### PR TITLE
Add PromptArmor - OWASP LLM Top 10 aligned prompt injection testing library

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Newly added projects are marked with 📌.
 - [guardrails](https://github.com/guardrails-ai/guardrails) (`GuardrailsAI`) ![](https://img.shields.io/github/stars/guardrails-ai/guardrails.svg?style=social) Adding guardrails to large language models.
 - [PurpleLlama](https://github.com/meta-llama/PurpleLlama) (`Meta`) ![](https://img.shields.io/github/stars/meta-llama/PurpleLlama.svg?style=social) Set of tools to assess and improve LLM security.
 - [llm-guard](https://github.com/protectai/llm-guard) (`ProtectAI`) ![](https://img.shields.io/github/stars/protectai/llm-guard.svg?style=social) The Security Toolkit for LLM Interactions
+- [PromptArmor](https://github.com/77QAlab/PromptArmor) - prompt injection testing library with 191 structured payloads in a two-level taxonomy. Mapped to OWASP LLM Top 10, MITRE ATLAS techniques, and CVSS-LLM severity scoring. For QA engineers and security testers validating LLM applications.
 
 ## LLM Cookbook / Examples
 - [openai-cookbook](https://github.com/openai/openai-cookbook) (`OpenAI`) ![](https://img.shields.io/github/stars/openai/openai-cookbook.svg?style=social) Examples and guides for using the OpenAI API


### PR DESCRIPTION
Adding PromptArmor to the LLM Guardrails/Security section.

PromptArmor is an open source prompt injection testing library:
- 191 structured payloads in a two-level taxonomy
- Mapped to OWASP LLM Top 10 (LLM01, LLM02, LLM06)
- MITRE ATLAS technique mapping (AML.T0051)
- CVSS-LLM severity classification per payload
- MIT licensed

Designed for QA engineers and security testers validating 
LLM applications against adversarial prompt injection, RAG 
poisoning, and AI agent manipulation.

Repository: https://github.com/77QAlab/PromptArmor